### PR TITLE
Add .yamllint + fix invalid .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,6 @@ workflows:
             - integration-test-1
           filters:
             branches:
-              only: 
+              only:
                 - master
                 - main

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+extends: relaxed
+
+rules:
+    line-length:
+        max: 200
+        allow-non-breakable-inline-mappings: true
+


### PR DESCRIPTION
This PR adds a default .yamllint that matches that of the orb-tools/lint job, so that when using yamllint locally you'll get the same behavior.

This PR also removes an empty character in .circleci/config.yml that was causing orb-tools/lint to fail by default.