### PR TITLE
Remove trailing space that causes linting failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,6 @@ workflows:
             - integration-test-1
           filters:
             branches:
-              only: 
+              only:
                 - master
                 - main


### PR DESCRIPTION
### Why:
When creating a new Orb with this automated process the first build will fail:

https://app.circleci.com/pipelines/github/nbialostosky/test-orb/1/workflows/78c31b13-1923-4e0e-aaa3-3bbc484375e2/jobs/3

However, when you remove the space in the `config.yml` file that is added via the automated process it causes it to pass:

https://github.com/nbialostosky/test-orb/commit/ec2e6c29241c12ae258741a76b4bcbb5612032c1

https://app.circleci.com/pipelines/github/nbialostosky/test-orb/2/workflows/d33264c2-2ea1-450b-8ae9-95fb0e71de2f/jobs/5

### What:
This PR will remove the trailing space from the template we utilize which should ensure newly generated Orbs from this template don't run into a linting error. 