### PR TITLE
Update license from 2020 to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 <organization>
+Copyright (c) 2021 <organization>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Why:
We are now in 2021 so any newly generated Orbs that use the automated process of Orb creation should have a 2021 date in the license. 

### What:
This PR will update the Copyright date from `2020` to `2021` in the `LICENSE` file.